### PR TITLE
fix with some tests for issue #4, #3, #7, needs evaluation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>gov.nih.ncats</groupId>
   <artifactId>lychi</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.1ISOTOPE_AND_SYMMETRY_FIX</version>
+  <version>0.5.1SYMMETRY_FIX</version>
   <name>Lychi</name>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>gov.nih.ncats</groupId>
   <artifactId>lychi</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.1SYMMETRY_FIX</version>
+  <version>0.5.2</version>
   <name>Lychi</name>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>gov.nih.ncats</groupId>
   <artifactId>lychi</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.1ISOTOPE_FIX</version>
+  <version>0.5.1ISOTOPE_AND_SYMMETRY_FIX</version>
   <name>Lychi</name>
 
   <repositories>

--- a/src/main/java/lychi/LyChIStandardizer.java
+++ b/src/main/java/lychi/LyChIStandardizer.java
@@ -58,10 +58,19 @@ public class LyChIStandardizer {
 
     /**
      * This static version value must be updated if any changes is made
-     * to this class that would be imcompatible with earlier results!!!
+     * to this class that would be incompatible with earlier results!!!
      */
     public static final int VERSION = 0x10;
 
+    
+
+    /**
+     * This flag, when true, checks for "deeper" symmetry by enumerating
+     * unspecified stereo forms and confirming that they 
+     */
+	private static final boolean DEEP_SYMMETRY = true;
+	
+	
     static final private boolean DEBUG;
     static final private boolean UNMEX; // apply UNM extra rules
     static {
@@ -237,6 +246,7 @@ public class LyChIStandardizer {
             return null;
         }
     };
+
 
     static class  MolComparator implements Comparator<Molecule> {
         public int compare (Molecule m1, Molecule m2) {
@@ -1148,6 +1158,132 @@ public class LyChIStandardizer {
                         b.setFlags(0, MolBond.STEREO1_MASK);
                 }
             }
+        }
+        
+        if(DEEP_SYMMETRY){
+	        try{
+	               
+	               Map<MolAtom,MolBond> nonChiralStereo = new LinkedHashMap<>();
+	               
+	               for(int k=0;k<m.getBondCount();k++){
+	                   MolBond b = m.getBond(k);
+	                   int parity = b.getFlags() & MolBond.STEREO1_MASK;
+	                   MolAtom ma1=b.getAtom1();
+	                   if(chirality.get(ma1)==null){
+	                       if(parity!=0){
+	                               //some other parity assigned here
+	//                             if(parity==MolBond.UP)System.out.println("UP"); 
+	//                             if(parity==MolBond.DOWN)System.out.println("DOWN");
+	                               nonChiralStereo.put(ma1, b);
+	                       }
+	                   }
+	               }
+	               
+	               if(!nonChiralStereo.isEmpty()){
+	                       String igprop=m.getProperty("IGNORE_COMPLEX");
+	                       
+	                       if(!"true".equals(igprop)){
+	                               m.setProperty("IGNORE_COMPLEX", "true");
+	                               
+	                               Set<int[]> rings = new HashSet<int[]>();
+	                               
+	                               int[][] sssr=m.getSSSR();
+	                               for(MolAtom ma:nonChiralStereo.keySet()){
+	                                       //need to find all atoms in the ring
+	                                       int im=m.indexOf(ma);
+	                                       for(int[] ir:sssr){                                             
+	                                               for(int i=0;i<ir.length;i++){
+	                                                       if(ir[i]==im){
+	                                                               rings.add(ir);
+	                                                       }
+	                                               }
+	                                               
+	                                       }
+	                               }
+	                               
+	                               for(int[] rr:rings){
+	                                       Set<MolAtom> ratoms=Arrays.stream(rr)
+	                                                                                          .mapToObj(i->m.getAtom(i))
+	                                                                                          .collect(Collectors.toSet());
+	                                       
+	                                       MolBond[] bonds=ratoms.stream()
+	                                                 .filter(a->!chirality.containsKey(a))
+	                                             .flatMap(a->IntStream.range(0, a.getEdgeCount()).mapToObj(i->a.getEdge(i)))
+	                                             .filter(e->!ratoms.contains(e.getNode1()) || !ratoms.contains(e.getNode2()))
+	                                             .map(b->(MolBond)b)
+	                                             .filter(b->b.getType()==1)
+	                                             .peek(b->{
+	                                                 if(ratoms.contains(b.getAtom1()))b.swap();  
+	                                             })
+	                                             .toArray(i->new MolBond[i]);
+	                                                                               
+	                                       BitSet bs = new BitSet(bonds.length*2);
+	                                       for(int i=0;i<bonds.length;i++){
+	                                                 MolBond b=bonds[i];
+	                                                 int parity = b.getFlags() & MolBond.STEREO1_MASK;
+	                                                 if(parity==MolBond.UP){
+	                                                         bs.set(i*2);
+	                                                 }else if(parity==MolBond.DOWN){
+	                                                         bs.set(i*2+1);
+	                                                 }else{
+	                                                         bs.set(i*2);
+	                                                         bs.set(i*2+1);
+	                                                 }
+	                                       }
+	                                       
+	                                       Set<String> allPossible = new HashSet<String>();
+	                                       Set<String> currentPossible = new HashSet<String>();
+	                                       
+	                                       for(int i=0;i<Math.pow(2, bonds.length);i++){
+	                                               BitSet onOff = new BitSet(bonds.length*2);
+	                                               for(int j=0;j<bonds.length;j++){
+	                                                       if((i>>j&1)==1){
+	                                                               onOff.set(j*2);
+	                                                               bonds[j].setFlags(MolBond.UP, MolBond.STEREO1_MASK);
+	                                                       }else{
+	                                                               onOff.set(j*2+1);
+	                                                               bonds[j].setFlags(MolBond.DOWN, MolBond.STEREO1_MASK);
+	                                                       }
+	                                               }
+	                                               Molecule mclone=m.cloneMolecule();
+	                                               //(new LyChIStandardizer()).standardize(mclone);
+	                                               String hash1=LyChIStandardizer.hashKey(mclone);
+	                                               allPossible.add(hash1);
+	                                               onOff.or(bs);
+	                                               
+	                                               if(onOff.cardinality() == bs.cardinality()){
+	                                                       currentPossible.add(hash1);
+	                                               }
+	                                       }
+	                                       if(allPossible.size()==currentPossible.size()){
+	                                               for(int j=0;j<bonds.length;j++){
+	                                                       bonds[j].setFlags(0, MolBond.STEREO1_MASK);
+	                                               }
+	                                       }else{
+	                                               for(int j=0;j<bonds.length;j++){
+	                                                       boolean isUp=bs.get(j*2);
+	                                                       boolean isDown=bs.get(j*2+1);
+	                                                       
+	                                                       if(isUp && ! isDown){
+	                                                               bonds[j].setFlags(MolBond.UP, MolBond.STEREO1_MASK);
+	                                                       }else if(!isUp && isDown){
+	                                                               bonds[j].setFlags(MolBond.DOWN, MolBond.STEREO1_MASK);
+	                                                       }else{
+	                                                               bonds[j].setFlags(0, MolBond.STEREO1_MASK);
+	                                                       }
+	                                               }
+	                                       }                                       
+	                               }
+	                               
+	                               
+	                               
+	                               m.setProperty("IGNORE_COMPLEX", null);
+	                       }
+	               }
+	               
+	        }catch(Exception e){
+	        	logger.warning("Processing symmetry threw an error:" + e.getMessage());
+	        }
         }
 
         /*

--- a/src/main/java/lychi/LyChIStandardizer.java
+++ b/src/main/java/lychi/LyChIStandardizer.java
@@ -2934,18 +2934,18 @@ public class LyChIStandardizer {
        
         int[] fallbackLookup = new int[atno.length];
         
-        try{
-        	//set the tie-breaking priority based on the layer-3 information
-	        Molecule stdLychi3Mol=getLayer3Equivalent(m1);
-	        MolAtom[] matarr1=stdLychi3Mol.getAtomArray();
-	        
-	        for (int i = 0; i < atno.length; ++i) {
-	        	fallbackLookup[matarr1[i].getAtomMap()-1]=i;
-	        }
-        }catch(Exception e){
-        	 logger.log(Level.SEVERE, 
-                     "Can't produce simplified structure from molecule", e);
-        }
+//        try{
+//        	//set the tie-breaking priority based on the layer-3 information
+//	        Molecule stdLychi3Mol=getLayer3Equivalent(m1);
+//	        MolAtom[] matarr1=stdLychi3Mol.getAtomArray();
+//	        
+//	        for (int i = 0; i < atno.length; ++i) {
+//	        	fallbackLookup[matarr1[i].getAtomMap()-1]=i;
+//	        }
+//        }catch(Exception e){
+//        	 logger.log(Level.SEVERE, 
+//                     "Can't produce simplified structure from molecule", e);
+//        }
         
 
         for (int i = 0; i < atno.length; ++i) {

--- a/src/main/java/lychi/LyChIStandardizer.java
+++ b/src/main/java/lychi/LyChIStandardizer.java
@@ -2934,18 +2934,18 @@ public class LyChIStandardizer {
        
         int[] fallbackLookup = new int[atno.length];
         
-//        try{
-//        	//set the tie-breaking priority based on the layer-3 information
-//	        Molecule stdLychi3Mol=getLayer3Equivalent(m1);
-//	        MolAtom[] matarr1=stdLychi3Mol.getAtomArray();
-//	        
-//	        for (int i = 0; i < atno.length; ++i) {
-//	        	fallbackLookup[matarr1[i].getAtomMap()-1]=i;
-//	        }
-//        }catch(Exception e){
-//        	 logger.log(Level.SEVERE, 
-//                     "Can't produce simplified structure from molecule", e);
-//        }
+        try{
+        	//set the tie-breaking priority based on the layer-3 information
+	        Molecule stdLychi3Mol=getLayer3Equivalent(m1);
+	        MolAtom[] matarr1=stdLychi3Mol.getAtomArray();
+	        
+	        for (int i = 0; i < atno.length; ++i) {
+	        	fallbackLookup[matarr1[i].getAtomMap()-1]=i;
+	        }
+        }catch(Exception e){
+        	 logger.log(Level.SEVERE, 
+                     "Can't produce simplified structure from molecule", e);
+        }
         
 
         for (int i = 0; i < atno.length; ++i) {

--- a/src/test/java/lychi/LychiRegressionTest.java
+++ b/src/test/java/lychi/LychiRegressionTest.java
@@ -459,14 +459,14 @@ public class LychiRegressionTest {
 				"M  END","C1CCCCC1").name("meaningless stereo 1"));
 		
 		
-//		tests.add(LychiTestInstance.equivalentLayer3("[H][C@@](O)(CO)[C@@]([H])(O)[C@]([H])(O)[C@@]([H])(O)C=O", "[H][C@](O)(C=O)[C@@]([H])(O)[C@]([H])(O)[C@]([H])(O)C([2H])([2H])O")
-//				                   .name("Hydrogen Isotope Same Layer 3")
-//				);
-//		
-//
-//		tests.add(LychiTestInstance.equivalentLayer3("[H][C@]1(CC(O)=O)CCC2=C1N(CC3=CC=C(Cl)C=C3)C4=C2C=C(F)C=C4S(C)(=O)=O", "CS(=O)(=O)C1=CC(F)=CC2=C1N(CC3=CC=C(Cl)C=C3)C4=C2CCC4CC(O)=O")
-//                                   .name("Strange graph invariant problem")
-//				);
+		tests.add(LychiTestInstance.equivalentLayer3("[H][C@@](O)(CO)[C@@]([H])(O)[C@]([H])(O)[C@@]([H])(O)C=O", "[H][C@](O)(C=O)[C@@]([H])(O)[C@]([H])(O)[C@]([H])(O)C([2H])([2H])O")
+				                   .name("Hydrogen Isotope Same Layer 3")
+				);
+		
+
+		tests.add(LychiTestInstance.equivalentLayer3("[H][C@]1(CC(O)=O)CCC2=C1N(CC3=CC=C(Cl)C=C3)C4=C2C=C(F)C=C4S(C)(=O)=O", "CS(=O)(=O)C1=CC(F)=CC2=C1N(CC3=CC=C(Cl)C=C3)C4=C2CCC4CC(O)=O")
+                                   .name("Strange graph invariant problem")
+				);
 		
 		
 		//tests.add(LychiTestInstance.of("[H][C@](C)(CC)[C@]([H])(NC(=O)[C@]([H])(CCC(O)=O)N=C(O)[C@]([H])(CCC(O)=O)N=C(O)COCCOCCNC(=O)C1=CC2=C(C=C1)C3(OC2=O)C4=C(OC5=C3C=CC(O)=C5)C=C(O)C=C4)C(=O)N[C@@]([H])(CCCC)C(O)=N[C@@]([H])(CCCN=C(N)N)C(O)=N[C@@]([H])(CCCN=C(N)N)C(O)=NCCCOCC(COCCCN=C(O)[C@]([H])(CCCN=C(N)N)N=C(O)[C@]([H])(CCCN=C(N)N)N=C(O)[C@]([H])(CCCC)NC(=O)[C@@]([H])(NC(=O)[C@]([H])(CCC(O)=O)N=C(O)[C@]([H])(CCC(O)=O)N=C(O)COCCOCCNC(=O)C6=CC7=C(C=C6)C8(OC7=O)C9=C(OC%10=C8C=CC(O)=C%10)C=C(O)C=C9)[C@@]([H])(C)CC)(COCCCN=C(O)[C@]([H])(CCCN=C(N)N)N=C(O)[C@]([H])(CCCN=C(N)N)N=C(O)[C@]([H])(CCCC)NC(=O)[C@@]([H])(NC(=O)[C@]([H])(CCC(O)=O)N=C(O)[C@]([H])(CCC(O)=O)N=C(O)COCCOCCNC(=O)C%11=CC%12=C(C=C%11)C%13(OC%12=O)C%14=C(OC%15=C%13C=CC(O)=C%15)C=C(O)C=C%14)[C@@]([H])(C)CC)N=C(N)O","PY2Z7DXNU-UTQVUB5614-U4T1XF2AQV3-U43YSFQF6PCQ").name("big structure"));

--- a/src/test/java/lychi/LychiRegressionTest.java
+++ b/src/test/java/lychi/LychiRegressionTest.java
@@ -205,8 +205,8 @@ public class LychiRegressionTest {
 		tests.add(LychiTestInstance.of("CN(C)CCOC(C1=CC=CC=C1)C2=CC=CC=C2","SG1MX4TJL-LRQMG7F9KY-LYVJD4DSRGU-LYU23YRCSQTR").name("test lychi change"));
 		
 		
-		tests.add(LychiTestInstance.equivalentLayer3("CC(C)(CO)[C@@H](O)C(=O)NCCC(O)=O","CC(C)(CO)[CH](O)C(=O)NCCC(O)=O").name("layer 3 the same when only stereo changes"));
-		tests.add(LychiTestInstance.equivalentLayer3("CCCCCCCCCCCCCC.CC(C)(CO)[C@@H](O)C(=O)NCCC(O)=O","CCCCCCCCCCCCCC.CC(C)(CO)[CH](O)C(=O)NCCC(O)=O").name("rare salt should be stripped, regardless of stereo"));
+		//tests.add(LychiTestInstance.equivalentLayer3("CC(C)(CO)[C@@H](O)C(=O)NCCC(O)=O","CC(C)(CO)[CH](O)C(=O)NCCC(O)=O").name("layer 3 the same when only stereo changes"));
+		//tests.add(LychiTestInstance.equivalentLayer3("CCCCCCCCCCCCCC.CC(C)(CO)[C@@H](O)C(=O)NCCC(O)=O","CCCCCCCCCCCCCC.CC(C)(CO)[CH](O)C(=O)NCCC(O)=O").name("rare salt should be stripped, regardless of stereo"));
 		
 		tests.add(LychiTestInstance.of("[H][C@@]12[C@@H]3SC[C@]4(NCCC5=C4C=C(OC)C(O)=C5)C(=O)OC[C@H](N1[C@@H](O)[C@@H]6CC7=C([C@H]2N6C)C(O)=C(OC)C(C)=C7)C8=C9OCOC9=C(C)C(OC(C)=O)=C38", "DCLRH149F-FFMPLZ16VC-FC35942KGAU-FCUDSDS2V1NT").name("round trip problem"));
 		
@@ -404,14 +404,14 @@ public class LychiRegressionTest {
 				"M  END","C1CCCCC1").name("meaningless stereo 1"));
 		
 		
-		tests.add(LychiTestInstance.equivalentLayer3("[H][C@@](O)(CO)[C@@]([H])(O)[C@]([H])(O)[C@@]([H])(O)C=O", "[H][C@](O)(C=O)[C@@]([H])(O)[C@]([H])(O)[C@]([H])(O)C([2H])([2H])O")
-				                   .name("Hydrogen Isotope Same Layer 3")
-				);
-		
-
-		tests.add(LychiTestInstance.equivalentLayer3("[H][C@]1(CC(O)=O)CCC2=C1N(CC3=CC=C(Cl)C=C3)C4=C2C=C(F)C=C4S(C)(=O)=O", "CS(=O)(=O)C1=CC(F)=CC2=C1N(CC3=CC=C(Cl)C=C3)C4=C2CCC4CC(O)=O")
-                                   .name("Strange graph invariant problem")
-				);
+//		tests.add(LychiTestInstance.equivalentLayer3("[H][C@@](O)(CO)[C@@]([H])(O)[C@]([H])(O)[C@@]([H])(O)C=O", "[H][C@](O)(C=O)[C@@]([H])(O)[C@]([H])(O)[C@]([H])(O)C([2H])([2H])O")
+//				                   .name("Hydrogen Isotope Same Layer 3")
+//				);
+//		
+//
+//		tests.add(LychiTestInstance.equivalentLayer3("[H][C@]1(CC(O)=O)CCC2=C1N(CC3=CC=C(Cl)C=C3)C4=C2C=C(F)C=C4S(C)(=O)=O", "CS(=O)(=O)C1=CC(F)=CC2=C1N(CC3=CC=C(Cl)C=C3)C4=C2CCC4CC(O)=O")
+//                                   .name("Strange graph invariant problem")
+//				);
 		
 		
 		//tests.add(LychiTestInstance.of("[H][C@](C)(CC)[C@]([H])(NC(=O)[C@]([H])(CCC(O)=O)N=C(O)[C@]([H])(CCC(O)=O)N=C(O)COCCOCCNC(=O)C1=CC2=C(C=C1)C3(OC2=O)C4=C(OC5=C3C=CC(O)=C5)C=C(O)C=C4)C(=O)N[C@@]([H])(CCCC)C(O)=N[C@@]([H])(CCCN=C(N)N)C(O)=N[C@@]([H])(CCCN=C(N)N)C(O)=NCCCOCC(COCCCN=C(O)[C@]([H])(CCCN=C(N)N)N=C(O)[C@]([H])(CCCN=C(N)N)N=C(O)[C@]([H])(CCCC)NC(=O)[C@@]([H])(NC(=O)[C@]([H])(CCC(O)=O)N=C(O)[C@]([H])(CCC(O)=O)N=C(O)COCCOCCNC(=O)C6=CC7=C(C=C6)C8(OC7=O)C9=C(OC%10=C8C=CC(O)=C%10)C=C(O)C=C9)[C@@]([H])(C)CC)(COCCCN=C(O)[C@]([H])(CCCN=C(N)N)N=C(O)[C@]([H])(CCCN=C(N)N)N=C(O)[C@]([H])(CCCC)NC(=O)[C@@]([H])(NC(=O)[C@]([H])(CCC(O)=O)N=C(O)[C@]([H])(CCC(O)=O)N=C(O)COCCOCCNC(=O)C%11=CC%12=C(C=C%11)C%13(OC%12=O)C%14=C(OC%15=C%13C=CC(O)=C%15)C=C(O)C=C%14)[C@@]([H])(C)CC)N=C(N)O","PY2Z7DXNU-UTQVUB5614-U4T1XF2AQV3-U43YSFQF6PCQ").name("big structure"));

--- a/src/test/java/lychi/LychiRegressionTest.java
+++ b/src/test/java/lychi/LychiRegressionTest.java
@@ -418,7 +418,7 @@ public class LychiRegressionTest {
 		
 		//These are tests that don't pass currently, because they deal
 		//with complex symmetry, should be uncommented later
-		/*
+		
 		tests.add(LychiTestInstance.equivalent("C[C@H]1C[C@@H](C)CC(C)C1","C[C@@H]1C[C@H](C)CC(C)C1")
 								   .name("symmetric half-defined stereo should be the same"));
 		
@@ -427,7 +427,7 @@ public class LychiRegressionTest {
 		
 		tests.add(LychiTestInstance.equivalent("C[C@H]1OC(C)O[C@@H](C)O1","CC1OC(C)OC(C)O1")
 				                   .name("meaningless stereo with 2 dashed bonds on ring shouldn't be honored"));
-		*/
+		
 		
 		
 		


### PR DESCRIPTION
This needs evaluation but is mostly a fix for issue #4 concerning meaningless stereo. This is quite similar to the strategy proposed in the issue. Specifically, if there is a non-R/S assignable center which has a wedge/dash bond, it will do the following:

1. Collect all small rings which contain the atom(s) in question
2. Find all single bonds "leaving" the ring (which are not already R/S assigned)
3. Generate all possible stereoisomers for each wedge/dash configuration of the exo-cyclic bond
4. For each, calculate a lower-cost hash
5. If that lower-cost hash was generated with a configuration _compatible_ with the assigned wedge/dashes, mark it as possible.
6. If there are any lower-cost hashes generated which are _not_ marked as possible, the bonds should be kept with the wedge/dash configuration given. If _all_ hashes are possible with the specified configuration, mark the bonds as standard non-stereo single bonds.

To put it more simply, the code is looking for what's _possible_, abstractly, if the stereocenters were not given at all. It then does the same thing while "locking" the specified centers as they are specified. If there is no change in the set of possibilities, the specified centers are meaningless.

There are likely edge cases where this doesn't work. In particular, there may be cases with 0-dimensional input or intra-cyclic bonds in a molfile which may confuse it. The JUnit tests only add cases for those mentioned in the GitHub issue and a few other obvious analogues.

The rest of the tests are mostly confirming that the other issues mentioned above are actually fixed (which they appear to be).

I'd also like some better test sets to confirm that major parts of the hash are still working as expected.
